### PR TITLE
squid:S1170 - Public constants and fields initialized at declaration …

### DIFF
--- a/bible/src/main/java/com/BibleQuote/async/AsyncOpenChapter.java
+++ b/bible/src/main/java/com/BibleQuote/async/AsyncOpenChapter.java
@@ -8,7 +8,7 @@ import com.BibleQuote.exceptions.OpenModuleException;
 import com.BibleQuote.managers.Librarian;
 
 public class AsyncOpenChapter extends Task {
-	private final String TAG = "AsyncOpenChapter";
+	private static final String TAG = "AsyncOpenChapter";
 
 	private Librarian librarian;
 	private BibleReference link;

--- a/bible/src/main/java/com/BibleQuote/async/AsyncOpenModule.java
+++ b/bible/src/main/java/com/BibleQuote/async/AsyncOpenModule.java
@@ -10,7 +10,7 @@ import com.BibleQuote.exceptions.OpenModuleException;
 import com.BibleQuote.managers.Librarian;
 
 public class AsyncOpenModule extends Task {
-	private final String TAG = "AsyncOpenBooks";
+	private static final String TAG = "AsyncOpenBooks";
 
 	private Librarian librarian;
 	private BibleReference link;

--- a/bible/src/main/java/com/BibleQuote/async/AsyncWait.java
+++ b/bible/src/main/java/com/BibleQuote/async/AsyncWait.java
@@ -4,7 +4,7 @@ import android.util.Log;
 import com.BibleQuote.utils.Task;
 
 public class AsyncWait extends Task {
-	private final String TAG = "AsyncWait";
+	private static final String TAG = "AsyncWait";
 	private AsyncTaskManager currentAsyncTaskManager;
 
 

--- a/bible/src/main/java/com/BibleQuote/async/command/InitApplication.java
+++ b/bible/src/main/java/com/BibleQuote/async/command/InitApplication.java
@@ -23,7 +23,7 @@ import com.BibleQuote.BibleQuoteApp;
 import com.BibleQuote.async.AsyncCommand;
 
 public class InitApplication implements AsyncCommand.ICommand {
-	private final String TAG = "InitApplication";
+	private static final String TAG = "InitApplication";
 	private Context context;
 
 	public InitApplication(Context context) {

--- a/bible/src/main/java/com/BibleQuote/async/command/StartSearch.java
+++ b/bible/src/main/java/com/BibleQuote/async/command/StartSearch.java
@@ -26,7 +26,7 @@ import com.BibleQuote.exceptions.OpenModuleException;
 import com.BibleQuote.managers.Librarian;
 
 public class StartSearch implements AsyncCommand.ICommand {
-    private final String TAG = "StartSearch";
+    private static final String TAG = "StartSearch";
     private String query, fromBookID, toBookID;
     private Context context;
 

--- a/bible/src/main/java/com/BibleQuote/controllers/CacheModuleController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/CacheModuleController.java
@@ -8,7 +8,7 @@ import com.BibleQuote.exceptions.FileAccessException;
 import java.util.ArrayList;
 
 public class CacheModuleController<TModule> {
-	private final String TAG = "CacheRepository";
+	private static final String TAG = "CacheRepository";
 
 	private CacheRepository<ArrayList<TModule>> cacheRepository;
 

--- a/bible/src/main/java/com/BibleQuote/controllers/FsBookController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/FsBookController.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 public class FsBookController implements IBookController {
-	private final String TAG = "FsBookController";
+	private static final String TAG = "FsBookController";
 
 	private IBookRepository<FsModule, FsBook> bRepository;
 	private IModuleRepository<String, FsModule> mRepository;

--- a/bible/src/main/java/com/BibleQuote/controllers/TSKController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/TSKController.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class TSKController {
 
-	private final int MAX_PULL_SIZE = 10;
+	private static final int MAX_PULL_SIZE = 10;
 
 	private ITskRepository repository;
 	private Map<String, LinkedHashSet<BibleReference>> bCrossReferenceCache = Collections

--- a/bible/src/main/java/com/BibleQuote/dal/FsLibraryContext.java
+++ b/bible/src/main/java/com/BibleQuote/dal/FsLibraryContext.java
@@ -42,7 +42,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FsLibraryContext extends LibraryContext {
-    private final String TAG = "FsLibraryContext";
+    private static final String TAG = "FsLibraryContext";
     public CacheModuleController<FsModule> cache;
     private File libraryDir = null;
 

--- a/bible/src/main/java/com/BibleQuote/dal/repository/CacheRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/CacheRepository.java
@@ -5,7 +5,7 @@ import com.BibleQuote.utils.Log;
 import com.BibleQuote.exceptions.FileAccessException;
 
 public class CacheRepository<T> {
-	private final String TAG = "CacheRepository";
+	private static final String TAG = "CacheRepository";
 
 	private CacheContext cacheContext;
 

--- a/bible/src/main/java/com/BibleQuote/dal/repository/FsChapterRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/FsChapterRepository.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class FsChapterRepository implements IChapterRepository<FsBook> {
-	private final String TAG = "FsChapterRepository";
+	private static final String TAG = "FsChapterRepository";
 	private FsLibraryContext context;
 
 	public FsChapterRepository(FsLibraryContext context) {

--- a/bible/src/main/java/com/BibleQuote/dal/repository/FsModuleRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/FsModuleRepository.java
@@ -37,7 +37,7 @@ import java.util.TreeMap;
 
 public class FsModuleRepository implements IModuleRepository<String, FsModule> {
 
-	private final String TAG = "FsModuleRepository";
+	private static final String TAG = "FsModuleRepository";
 	private FsLibraryContext context;
 	private CacheModuleController<FsModule> cache;
 

--- a/bible/src/main/java/com/BibleQuote/dal/repository/fsHistoryRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/fsHistoryRepository.java
@@ -31,8 +31,8 @@ import java.util.LinkedList;
 
 public class fsHistoryRepository implements IHistoryRepository {
 	private File dirPath;
-	private final String historyFileName = "history.dat";
-	private final String TAG = "fsHistoryRepository";
+	private static final String historyFileName = "history.dat";
+	private static final String TAG = "fsHistoryRepository";
 
 	public fsHistoryRepository(File file) {
 		this.dirPath = file;

--- a/bible/src/main/java/com/BibleQuote/entity/BibleReference.java
+++ b/bible/src/main/java/com/BibleQuote/entity/BibleReference.java
@@ -10,10 +10,10 @@ public class BibleReference {
 	public final static String MOD_DATASOURCE_FS = "fs";
 	public final static String MOD_DATASOURCE_DB = "db";
 
-	private final String TAG = "LinkOSIS";
-	private final String SEP_GROUPS = "\\;";
-	private final String SEP_VALUES = "\\:";
-	private final String SEP_SHORT = "\\.";
+	private static final String TAG = "LinkOSIS";
+	private static final String SEP_GROUPS = "\\;";
+	private static final String SEP_VALUES = "\\:";
+	private static final String SEP_SHORT = "\\.";
 
 	private String OSISLinkPath = null;
 	private String moduleDatasource = null;

--- a/bible/src/main/java/com/BibleQuote/managers/Librarian.java
+++ b/bible/src/main/java/com/BibleQuote/managers/Librarian.java
@@ -48,7 +48,7 @@ import java.util.*;
 
 public class Librarian {
 
-	private final String TAG = "Librarian";
+	private static final String TAG = "Librarian";
 
 	private LinkedHashMap<String, String> searchResults = new LinkedHashMap<String, String>();
 

--- a/bible/src/main/java/com/BibleQuote/ui/LibraryActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/LibraryActivity.java
@@ -48,7 +48,7 @@ public class LibraryActivity extends BibleQuoteActivity implements OnTaskComplet
     public static final String EMPTY_OBJECT = "---";
 	private static final int ACTION_CODE_GET_FILE = 1;
     private static final String TAG = "LibraryActivity";
-    private final int MODULE_VIEW = 1, BOOK_VIEW = 2, CHAPTER_VIEW = 3;
+    private static final int MODULE_VIEW = 1, BOOK_VIEW = 2, CHAPTER_VIEW = 3;
 	private String moduleID = EMPTY_OBJECT, bookID = EMPTY_OBJECT, chapter = EMPTY_OBJECT;
     private int viewMode = 1;
     private ListView modulesList, booksList;

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ReaderWebView.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ReaderWebView.java
@@ -34,7 +34,7 @@ import java.util.TreeSet;
 public class ReaderWebView extends WebView
 		implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener {
 
-	final String TAG = "ReaderWebView";
+	static final String TAG = "ReaderWebView";
 
 	private GestureDetector mGestureScanner;
 	private JavaScriptInterface jsInterface;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1170 - Public constants and fields initialized at declaration should be "static final" rather than merely "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1170

Please let me know if you have any questions.

M-Ezzat