### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/bible/src/main/java/com/BibleQuote/dal/dbLibraryHelper.java
+++ b/bible/src/main/java/com/BibleQuote/dal/dbLibraryHelper.java
@@ -30,7 +30,7 @@ import java.io.File;
  * User: Vladimir Yakushev
  * Date: 02.05.13
  */
-public class dbLibraryHelper {
+public final class dbLibraryHelper {
 	private final static String TAG = dbLibraryHelper.class.getSimpleName();
 
 	private static int version = 2;
@@ -39,6 +39,10 @@ public class dbLibraryHelper {
 	public static final String TAGS_TABLE = "tags";
 	public static final String BOOKMARKSTAGS_TABLE = "bookmarks_tags";
 	public static final String BOOKMARKS_TABLE = "bookmarks";
+
+	private dbLibraryHelper() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	private static final String[] CREATE_DATABASE = new String[] {
 			"create table " + BOOKMARKS_TABLE + " ("

--- a/bible/src/main/java/com/BibleQuote/entity/BibleBooksID.java
+++ b/bible/src/main/java/com/BibleQuote/entity/BibleBooksID.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 
 //import android.util.Log;
 
-public class BibleBooksID {
+public final class BibleBooksID {
 
 	//private final static String TAG = "BibleBooksID";
 
@@ -183,6 +183,10 @@ public class BibleBooksID {
 			put("Herm.Vis", new String[]{"Herm.Vis", "Shepherd of Hermas, Visions"});
 		}
 	};
+
+	private BibleBooksID() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	private static void qualifierInit() {
 		qualifier = new HashMap<String, String>();

--- a/bible/src/main/java/com/BibleQuote/exceptions/ExceptionHelper.java
+++ b/bible/src/main/java/com/BibleQuote/exceptions/ExceptionHelper.java
@@ -21,7 +21,11 @@ import android.util.Log;
 import com.BibleQuote.R;
 import com.BibleQuote.utils.NotifyDialog;
 
-public class ExceptionHelper {
+public final class ExceptionHelper {
+
+    private ExceptionHelper() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static void onException(Exception ex, Context context, String tag) {
         String message = ex.getMessage();

--- a/bible/src/main/java/com/BibleQuote/managers/bookmarks/BookmarksTags.java
+++ b/bible/src/main/java/com/BibleQuote/managers/bookmarks/BookmarksTags.java
@@ -20,8 +20,13 @@ package com.BibleQuote.managers.bookmarks;
  * User: Vladimir
  * Date: 23.10.13
  */
-public class BookmarksTags {
+public final class BookmarksTags {
 	public static final String BOOKMARKSTAGS_KEY_ID = "_id";
 	public static final String BOOKMARKSTAGS_BM_ID = "bm_id";
 	public static final String BOOKMARKSTAGS_TAG_ID = "tag_id";
+
+	private BookmarksTags() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
+
 }

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/DrawingUtils.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/DrawingUtils.java
@@ -9,6 +9,11 @@ import android.util.TypedValue;
  * @version 1.0 of 03.2016
  */
 public class DrawingUtils {
+
+    private DrawingUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static int dpToPx(Context c, float dipValue) {
         DisplayMetrics metrics = c.getResources().getDisplayMetrics();
         float val = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dipValue, metrics);

--- a/bible/src/main/java/com/BibleQuote/utils/BibleLinkParser.java
+++ b/bible/src/main/java/com/BibleQuote/utils/BibleLinkParser.java
@@ -5,12 +5,16 @@ import com.BibleQuote.entity.BibleReference;
 
 import java.util.LinkedHashSet;
 
-public class BibleLinkParser {
+public final class BibleLinkParser {
 
 
 	//private static final String VERSE_SEPARATOR = ":";
 	private static final String TO_VERSE_SEPARATOR = "-";
 	private static final String LINK_SEPARATOR = ";";
+
+	private BibleLinkParser() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	public static LinkedHashSet<BibleReference> parse(String moduleID, String references) {
 

--- a/bible/src/main/java/com/BibleQuote/utils/FsUtils.java
+++ b/bible/src/main/java/com/BibleQuote/utils/FsUtils.java
@@ -38,8 +38,12 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 
-public class FsUtils {
+public final class FsUtils {
 	private static final String TAG = "FsUtils";
+
+	private FsUtils() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	public static BufferedReader getTextFileReaderFromZipArchive(String archivePath, String textFileInArchive,
 																 String textFileEncoding) throws FileAccessException {

--- a/bible/src/main/java/com/BibleQuote/utils/Log.java
+++ b/bible/src/main/java/com/BibleQuote/utils/Log.java
@@ -30,8 +30,12 @@ import java.util.Locale;
  *
  * @author Владимир Якушев (ru.phoenix@gmail.com)
  */
-public class Log {
+public final class Log {
 	static private File logFile;
+
+	private Log() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	/**
 	 * Подготовка файла-протокола событий. Создание нового файла,

--- a/bible/src/main/java/com/BibleQuote/utils/PreferenceHelper.java
+++ b/bible/src/main/java/com/BibleQuote/utils/PreferenceHelper.java
@@ -20,7 +20,7 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
-public class PreferenceHelper {
+public final class PreferenceHelper {
 
 	private final static String TAG = "Share";
 
@@ -28,6 +28,10 @@ public class PreferenceHelper {
 
 	private static Context mContext;
 	private static SharedPreferences preference;
+
+	private PreferenceHelper() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	static public void Init(Context context) {
 		mContext = context;

--- a/bible/src/main/java/com/BibleQuote/utils/UpdateManager.java
+++ b/bible/src/main/java/com/BibleQuote/utils/UpdateManager.java
@@ -18,9 +18,13 @@ import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-public class UpdateManager {
+public final class UpdateManager {
 
 	private final static String TAG = "UpdateManager";
+
+	private UpdateManager() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	static public void Init(Context context) {
 

--- a/bible/src/main/java/com/BibleQuote/utils/modules/LanguageConvertor.java
+++ b/bible/src/main/java/com/BibleQuote/utils/modules/LanguageConvertor.java
@@ -21,7 +21,12 @@ package com.BibleQuote.utils.modules;
  * Date: 10.02.13
  * Time: 0:35
  */
-public class LanguageConvertor {
+public final class LanguageConvertor {
+	
+	private LanguageConvertor() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
+
 	public static String getISOLanguage(String language) {
 		language = language.toLowerCase();
 		if (language.equals("русский") || language.equals("russian")) {

--- a/bible/src/main/java/com/BibleQuote/utils/modules/LinkConverter.java
+++ b/bible/src/main/java/com/BibleQuote/utils/modules/LinkConverter.java
@@ -24,7 +24,11 @@ import com.BibleQuote.exceptions.BookNotFoundException;
 import com.BibleQuote.exceptions.OpenModuleException;
 import com.BibleQuote.managers.Librarian;
 
-public class LinkConverter {
+public final class LinkConverter {
+
+	private LinkConverter() throws InstantiationException {
+		throw new InstantiationException("This class is not for instantiation");
+	}
 
 	public static String getOSIStoHuman(String linkOSIS, Librarian librarian) throws BookNotFoundException, OpenModuleException {
 		String[] param = linkOSIS.split("\\.");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat