### PR TITLE
squid:S00119, squid:S2326 - Type parameter names should comply with a…

### DIFF
--- a/bible/src/main/java/com/BibleQuote/controllers/CacheModuleController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/CacheModuleController.java
@@ -7,25 +7,25 @@ import com.BibleQuote.exceptions.FileAccessException;
 
 import java.util.ArrayList;
 
-public class CacheModuleController<TModule> {
+public class CacheModuleController<T> {
 	private static final String TAG = "CacheRepository";
 
-	private CacheRepository<ArrayList<TModule>> cacheRepository;
+	private CacheRepository<ArrayList<T>> cacheRepository;
 
 	public CacheModuleController(CacheContext cacheContext) {
 		this.cacheRepository = getCacheRepository(cacheContext);
 	}
 
-	public ArrayList<TModule> getModuleList() {
+	public ArrayList<T> getModuleList() {
 		Log.i(TAG, "Get module list");
 		try {
 			return cacheRepository.getData();
 		} catch (FileAccessException e) {
-			return new ArrayList<TModule>();
+			return new ArrayList<T>();
 		}
 	}
 
-	public void saveModuleList(ArrayList<TModule> moduleList) {
+	public void saveModuleList(ArrayList<T> moduleList) {
 		Log.i(TAG, "Save modules list to cache");
 		try {
 			cacheRepository.saveData(moduleList);
@@ -38,9 +38,9 @@ public class CacheModuleController<TModule> {
 		return cacheRepository.isCacheExist();
 	}
 
-	private CacheRepository<ArrayList<TModule>> getCacheRepository(CacheContext cacheContext) {
+	private CacheRepository<ArrayList<T>> getCacheRepository(CacheContext cacheContext) {
 		if (this.cacheRepository == null) {
-			this.cacheRepository = new CacheRepository<ArrayList<TModule>>(cacheContext);
+			this.cacheRepository = new CacheRepository<ArrayList<T>>(cacheContext);
 		}
 		return cacheRepository;
 	}

--- a/bible/src/main/java/com/BibleQuote/dal/ILibraryUnitOfWork.java
+++ b/bible/src/main/java/com/BibleQuote/dal/ILibraryUnitOfWork.java
@@ -5,15 +5,15 @@ import com.BibleQuote.controllers.CacheModuleController;
 import com.BibleQuote.dal.repository.IBookRepository;
 import com.BibleQuote.dal.repository.IModuleRepository;
 
-public interface ILibraryUnitOfWork<TModuleId, TModule, TBook> {
+public interface ILibraryUnitOfWork<T, S, U> {
 
-	public IModuleRepository<TModuleId, TModule> getModuleRepository();
+	public IModuleRepository<S> getModuleRepository();
 
-	public IBookRepository<TModule, TBook> getBookRepository();
+	public IBookRepository<S, U> getBookRepository();
 
-	public IChapterRepository<TBook> getChapterRepository();
+	public IChapterRepository<U> getChapterRepository();
 
 	public LibraryContext getLibraryContext();
 
-	public CacheModuleController<TModule> getCacheModuleController();
+	public CacheModuleController<S> getCacheModuleController();
 }

--- a/bible/src/main/java/com/BibleQuote/dal/repository/IChapterRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/IChapterRepository.java
@@ -5,15 +5,15 @@ import com.BibleQuote.modules.Chapter;
 
 import java.util.Collection;
 
-public interface IChapterRepository<TBook> {
+public interface IChapterRepository<T> {
 
 	/*
 	 * Data source related methods
 	 * 
 	 */
-	Collection<Chapter> loadChapters(TBook book) throws BookNotFoundException;
+	Collection<Chapter> loadChapters(T book) throws BookNotFoundException;
 
-	Chapter loadChapter(TBook book, Integer chapterNumber) throws BookNotFoundException;
+	Chapter loadChapter(T book, Integer chapterNumber) throws BookNotFoundException;
 
 	void insertChapter(Chapter chapter);
 
@@ -25,8 +25,8 @@ public interface IChapterRepository<TBook> {
 	 * Internal cache related methods
 	 *
 	 */
-	Collection<Chapter> getChapters(TBook book);
+	Collection<Chapter> getChapters(T book);
 
-	Chapter getChapterByNumber(TBook book, Integer chapterNumber);
+	Chapter getChapterByNumber(T book, Integer chapterNumber);
 
 }

--- a/bible/src/main/java/com/BibleQuote/dal/repository/IModuleRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/IModuleRepository.java
@@ -27,7 +27,7 @@ import com.BibleQuote.modules.Module;
 
 import java.util.Map;
 
-public interface IModuleRepository<TModuleId, TModule> {
+public interface IModuleRepository<T> {
 
 	/**
 	 * Загрузка списка модулей из хранилища без чтения данных.
@@ -36,11 +36,11 @@ public interface IModuleRepository<TModuleId, TModule> {
 	 */
 	Map<String, Module> loadFileModules();
 
-	void insertModule(TModule module);
+	void insertModule(T module);
 
 	void deleteModule(String moduleID);
 
-	void updateModule(TModule module);
+	void updateModule(T module);
 
 	void loadModule(String path) throws OpenModuleException;
 
@@ -53,6 +53,6 @@ public interface IModuleRepository<TModuleId, TModule> {
 	 * @param moduleID - ShortName модуля
 	 * @return Возвращает модуль из коллекции по его ShortName
 	 */
-	TModule getModuleByID(String moduleID);
+	T getModuleByID(String moduleID);
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S00119 - Type parameter names should comply with a naming convention
squid:S2326 - Unused type parameters should be removed

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00119
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2326

Please let me know if you have any questions.

M-Ezzat