### PR TITLE
squid:S2864 - "entrySet()" should be iterated when both the key and v…

### DIFF
--- a/bible/src/main/java/com/BibleQuote/entity/BibleBooksID.java
+++ b/bible/src/main/java/com/BibleQuote/entity/BibleBooksID.java
@@ -18,6 +18,7 @@ package com.BibleQuote.entity;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 //import android.util.Log;
 
@@ -190,10 +191,10 @@ public final class BibleBooksID {
 
 	private static void qualifierInit() {
 		qualifier = new HashMap<String, String>();
-		for (String key : bookShortNames.keySet()) {
-			String[] bookNames = bookShortNames.get(key);
+		for (Map.Entry<String, String[]> entry : bookShortNames.entrySet()) {
+			String[] bookNames = entry.getValue();
 			for (String name : bookNames) {
-				qualifier.put(name.toLowerCase(), key);
+				qualifier.put(name.toLowerCase(), entry.getKey());
 			}
 		}
 	}

--- a/bible/src/main/java/com/BibleQuote/managers/Librarian.java
+++ b/bible/src/main/java/com/BibleQuote/managers/Librarian.java
@@ -383,8 +383,8 @@ public class Librarian {
         formatter.setVisibleVerseNumbers(false);
 
 		LinkedHashMap<Integer, String> verses = getCurrChapter().getVerses(selectVerses);
-        for (Integer key : verses.keySet()) {
-            verses.put(key, formatter.format(verses.get(key)));
+        for (Map.Entry<Integer, String> entry : verses.entrySet()) {
+            verses.put(entry.getKey(), formatter.format(entry.getValue()));
         }
 
 		ShareBuilder builder = new ShareBuilder(context, getCurrModule(), getCurrBook(), getCurrChapter(), verses);

--- a/bible/src/main/java/com/BibleQuote/modules/Chapter.java
+++ b/bible/src/main/java/com/BibleQuote/modules/Chapter.java
@@ -4,6 +4,7 @@ import com.BibleQuote.utils.textFormatters.ITextFormatter;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -31,8 +32,8 @@ public class Chapter {
 	public String getText() {
 		if (text == null && verses.size() > 0) {
 			StringBuilder buffer = new StringBuilder();
-			for (Integer verseNumber : verses.keySet()) {
-				buffer.append(verses.get(verseNumber).getText());
+			for (Map.Entry<Integer, Verse> entry : verses.entrySet()) {
+				buffer.append(entry.getValue().getText());
 			}
 			text = buffer.toString();
 		}
@@ -86,8 +87,8 @@ public class Chapter {
 
 	public ArrayList<Verse> getVerseList() {
 		ArrayList<Verse> verseList = new ArrayList<Verse>();
-		for (Integer verse : verses.keySet()) {
-			verseList.add(verses.get(verse));
+		for (Map.Entry<Integer, Verse> entry : verses.entrySet()) {
+			verseList.add(entry.getValue());
 		}
 		return verseList;
 	}

--- a/bible/src/main/java/com/BibleQuote/ui/CrossReferenceActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/CrossReferenceActivity.java
@@ -40,6 +40,7 @@ import com.BibleQuote.ui.widget.listview.item.Item;
 import com.BibleQuote.ui.widget.listview.item.SubtextItem;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,11 +125,11 @@ public class CrossReferenceActivity extends BibleQuoteActivity implements OnTask
 
 	private void setListAdapter() {
 		List<Item> items = new ArrayList<Item>();
-		for (String link : crossReference.keySet()) {
+		for (Map.Entry<String, BibleReference> entry : crossReference.entrySet()) {
 			if (PreferenceHelper.crossRefViewDetails()) {
-				items.add(new SubtextItem(link, crossReferenceContent.get(crossReference.get(link))));
+				items.add(new SubtextItem(entry.getKey(), crossReferenceContent.get(entry.getValue())));
 			} else {
-				items.add(new TextItem(link));
+				items.add(new TextItem(entry.getKey()));
 			}
 		}
 

--- a/bible/src/main/java/com/BibleQuote/ui/SearchActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/SearchActivity.java
@@ -42,6 +42,7 @@ import com.BibleQuote.ui.widget.listview.item.SubtextItem;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class SearchActivity extends BibleQuoteActivity implements OnTaskCompleteListener {
 	private static final String TAG = "SearchActivity";
@@ -158,11 +159,11 @@ public class SearchActivity extends BibleQuoteActivity implements OnTaskComplete
 	 */
 	private void setAdapter() {
 		searchItems.clear();
-		for (String key : searchResults.keySet()) {
+		for (Map.Entry<String, String> entry : searchResults.entrySet()) {
 			String humanLink;
 			try {
-				humanLink = LinkConverter.getOSIStoHuman(key, myLibararian);
-				searchItems.add(new SubtextItem(humanLink, searchResults.get(key)));
+				humanLink = LinkConverter.getOSIStoHuman(entry.getKey(), myLibararian);
+				searchItems.add(new SubtextItem(humanLink, entry.getValue()));
 			} catch (BookNotFoundException e) {
 				ExceptionHelper.onBookNotFoundException(e, this, TAG);
 			} catch (OpenModuleException e) {

--- a/bible/src/main/java/com/BibleQuote/ui/fragments/TagsFragment.java
+++ b/bible/src/main/java/com/BibleQuote/ui/fragments/TagsFragment.java
@@ -39,6 +39,7 @@ import com.BibleQuote.ui.widget.listview.item.TagItem;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * User: Vladimir Yakushev
@@ -133,8 +134,8 @@ public class TagsFragment extends ListFragment implements AdapterView.OnItemLong
     private void setAdapter() {
         List<Item> items = new ArrayList<Item>();
         LinkedHashMap<Tag, String> tagList = tagManager.getAllWithCount();
-        for (Tag currTag : tagList.keySet()) {
-            items.add(new TagItem(currTag, tagList.get(currTag)));
+        for (Map.Entry<Tag, String> entry : tagList.entrySet()) {
+            items.add(new TagItem(entry.getKey(), entry.getValue()));
         }
         ItemAdapter adapter = new ItemAdapter(getActivity(), items);
         setListAdapter(adapter);

--- a/bible/src/main/java/com/BibleQuote/utils/textFormatters/BreakVerseBibleShareFormatter.java
+++ b/bible/src/main/java/com/BibleQuote/utils/textFormatters/BreakVerseBibleShareFormatter.java
@@ -1,6 +1,7 @@
 package com.BibleQuote.utils.textFormatters;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class BreakVerseBibleShareFormatter implements IShareTextFormatter {
 	private LinkedHashMap<Integer, String> verses;
@@ -13,12 +14,12 @@ public class BreakVerseBibleShareFormatter implements IShareTextFormatter {
 	public String format() {
 		StringBuilder shareText = new StringBuilder();
 
-		for (Integer verseNumber : verses.keySet()) {
+		for (Map.Entry<Integer, String> entry : verses.entrySet()) {
 			if (shareText.length() != 0) {
 				shareText.append(" ");
 			}
-			shareText.append(String.format("%1$s %2$s", verseNumber,
-					verses.get(verseNumber))
+			shareText.append(String.format("%1$s %2$s", entry.getKey(),
+					entry.getValue())
 					+ "\r\n");
 		}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat