### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/bible/src/main/java/com/BibleQuote/controllers/FsBookController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/FsBookController.java
@@ -39,7 +39,7 @@ public class FsBookController implements IBookController {
 
 	public ArrayList<Book> getBookList(Module module) throws BooksDefinitionException, BookDefinitionException, OpenModuleException {
 		ArrayList<FsBook> bookList = (ArrayList<FsBook>) bRepository.getBooks((FsModule) module);
-		if (bookList.size() == 0) {
+		if (bookList.isEmpty()) {
 			bookList = loadBooks((FsModule) module);
 		}
 		return new ArrayList<Book>(bookList);

--- a/bible/src/main/java/com/BibleQuote/controllers/FsChapterController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/FsChapterController.java
@@ -48,7 +48,7 @@ public class FsChapterController implements IChapterController {
 	public ArrayList<Chapter> getChapterList(Book book) throws BookNotFoundException {
 		book = getValidBook(book);
 		ArrayList<Chapter> chapterList = (ArrayList<Chapter>) chRepository.getChapters((FsBook) book);
-		if (chapterList.size() == 0) {
+		if (chapterList.isEmpty()) {
 			chapterList = (ArrayList<Chapter>) chRepository.loadChapters((FsBook) book);
 		}
 		return chapterList;

--- a/bible/src/main/java/com/BibleQuote/controllers/FsModuleController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/FsModuleController.java
@@ -46,7 +46,7 @@ public class FsModuleController implements IModuleController {
 	@Override
 	public Map<String, Module> getModules() {
 		Map<String, Module> result = mRepository.getModules();
-		if (result.size() == 0) {
+		if (result.isEmpty()) {
 			return loadFileModules();
 		} else {
 			return result;

--- a/bible/src/main/java/com/BibleQuote/dal/FsLibraryContext.java
+++ b/bible/src/main/java/com/BibleQuote/dal/FsLibraryContext.java
@@ -347,7 +347,7 @@ public class FsLibraryContext extends LibraryContext {
                         // Возьмем то, что есть до теги начала главы и добавим
                         // к найденным строкам
                         str = str.substring(0, str.toLowerCase().indexOf(chapterSign));
-                        if (str.trim().length() > 0) {
+                        if (!str.trim().isEmpty()) {
                             lines.add(str);
                         }
                         break;
@@ -377,7 +377,7 @@ public class FsLibraryContext extends LibraryContext {
             if (currLine.toLowerCase().contains(verseSign)) {
                 i++;
                 verseList.add(new Verse(i, currLine));
-            } else if (verseList.size() > 0) {
+            } else if (!verseList.isEmpty()) {
                 verseList.set(i, new Verse(i, verseList.get(i).getText() + " " + currLine));
             }
         }

--- a/bible/src/main/java/com/BibleQuote/dal/repository/FsModuleRepository.java
+++ b/bible/src/main/java/com/BibleQuote/dal/repository/FsModuleRepository.java
@@ -151,7 +151,7 @@ public class FsModuleRepository implements IModuleRepository<String, FsModule> {
 	}
 
 	public Map<String, Module> getModules() {
-		if ((context.moduleSet == null || context.moduleSet.size() == 0) && cache.isCacheExist()) {
+		if ((context.moduleSet == null || context.moduleSet.isEmpty()) && cache.isCacheExist()) {
 			Log.i(TAG, "....Load modules from cache");
 			loadCachedModules();
 		}

--- a/bible/src/main/java/com/BibleQuote/entity/BibleBooksID.java
+++ b/bible/src/main/java/com/BibleQuote/entity/BibleBooksID.java
@@ -215,7 +215,7 @@ public final class BibleBooksID {
 	public static String getID(ArrayList<String> shortNames) {
 		String result = null;
 
-		if (shortNames.size() == 0) {
+		if (shortNames.isEmpty()) {
 			return result;
 		}
 

--- a/bible/src/main/java/com/BibleQuote/modules/Book.java
+++ b/bible/src/main/java/com/BibleQuote/modules/Book.java
@@ -51,7 +51,7 @@ public abstract class Book implements Serializable {
 
 
 	public ArrayList<String> getChapterNumbers(Boolean isChapterZero) {
-		if (chapterQty > 0 && chapterNumbers.size() == 0) {
+		if (chapterQty > 0 && chapterNumbers.isEmpty()) {
 			for (int i = 0; i < chapterQty; i++) {
 				chapterNumbers.add("" + (i + (isChapterZero ? 0 : 1)));
 			}

--- a/bible/src/main/java/com/BibleQuote/modules/Chapter.java
+++ b/bible/src/main/java/com/BibleQuote/modules/Chapter.java
@@ -29,7 +29,7 @@ public class Chapter {
 	}
 
 	public String getText() {
-		if (text == null && verses.size() > 0) {
+		if (text == null && !verses.isEmpty()) {
 			StringBuilder buffer = new StringBuilder();
 			for (Integer verseNumber : verses.keySet()) {
 				buffer.append(verses.get(verseNumber).getText());

--- a/bible/src/main/java/com/BibleQuote/ui/LibraryActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/LibraryActivity.java
@@ -255,7 +255,7 @@ public class LibraryActivity extends BibleQuoteActivity implements OnTaskComplet
             try {
                 bookShortName = myLibrarian.getBookShortName(moduleID, bookID);
                 ArrayList<String> chList = myLibrarian.getChaptersList(moduleID, bookID);
-                if (chList.size() != 0) {
+                if (!chList.isEmpty()) {
                     chapter = chList.contains(chapter) ? chapter : chList.get(0);
                 } else {
                     chapter = EMPTY_OBJECT;
@@ -355,7 +355,7 @@ public class LibraryActivity extends BibleQuoteActivity implements OnTaskComplet
 
     private SimpleAdapter getBookAdapter() {
         books = new ArrayList<ItemList>();
-        if (myLibrarian.getModulesList().size() > 0) {
+        if (!myLibrarian.getModulesList().isEmpty()) {
             try {
                 books = myLibrarian.getModuleBooksList(moduleID);
             } catch (OpenModuleException e) {

--- a/bible/src/main/java/com/BibleQuote/ui/ReaderActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/ReaderActivity.java
@@ -279,7 +279,7 @@ public class ReaderActivity extends BibleQuoteActivity implements OnTaskComplete
             viewChapterNav();
         } else if (code == ChangeCode.onChangeSelection) {
             TreeSet<Integer> selVerses = vWeb.getSelectedVerses();
-            if (selVerses.size() == 0) {
+            if (selVerses.isEmpty()) {
                 disableActionMode();
             } else if (currActionMode == null) {
                 currActionMode = startSupportActionMode(new SelectTextHandler(this, vWeb));

--- a/bible/src/main/java/com/BibleQuote/ui/SearchActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/SearchActivity.java
@@ -181,7 +181,7 @@ public class SearchActivity extends BibleQuoteActivity implements OnTaskComplete
 		}
 
 		String title = getResources().getString(R.string.search);
-		if (searchResults.size() > 0) {
+		if (!searchResults.isEmpty()) {
 			title += " (" + searchResults.size() + " "
 					+ getResources().getString(R.string.results) + ")";
 		}

--- a/bible/src/main/java/com/BibleQuote/ui/handlers/SelectTextHandler.java
+++ b/bible/src/main/java/com/BibleQuote/ui/handlers/SelectTextHandler.java
@@ -47,7 +47,7 @@ public final class SelectTextHandler implements ActionMode.Callback {
     @Override
     public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
         TreeSet<Integer> selVerses = webView.getSelectedVerses();
-        if (selVerses.size() == 0) {
+        if (selVerses.isEmpty()) {
             return true;
         }
 

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ReaderWebView.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ReaderWebView.java
@@ -152,7 +152,7 @@ public class ReaderWebView extends WebView
 	}
 
 	public void clearSelectedVerse() {
-		if (selectedVerse.size() == 0) {
+		if (selectedVerse.isEmpty()) {
 			return;
 		}
 		jsInterface.clearSelectedVerse();

--- a/bible/src/main/java/com/BibleQuote/utils/modules/LinkConverter.java
+++ b/bible/src/main/java/com/BibleQuote/utils/modules/LinkConverter.java
@@ -78,7 +78,7 @@ public final class LinkConverter {
 		}
 		String linkOSIS = humanLink.substring(0, position).trim();
 		humanLink = humanLink.substring(position + 1).trim();
-		if (humanLink.length() == 0) {
+		if (humanLink.isEmpty()) {
 			return "";
 		}
 
@@ -89,7 +89,7 @@ public final class LinkConverter {
 		}
 		linkOSIS += "." + BibleBooksID.getID(humanLink.substring(0, position).trim());
 		humanLink = humanLink.substring(position).trim();
-		if (humanLink.length() == 0) {
+		if (humanLink.isEmpty()) {
 			return linkOSIS + ".1";
 		}
 
@@ -100,7 +100,7 @@ public final class LinkConverter {
 		}
 		linkOSIS += "." + humanLink.substring(0, position).trim().replaceAll("\\D", "");
 		humanLink = humanLink.substring(position).trim().replaceAll("\\D", "");
-		if (humanLink.length() == 0) {
+		if (humanLink.isEmpty()) {
 			return linkOSIS;
 		} else {
 			// Оставшийся кусок - номер стиха


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat