### PR TITLE
squid:UselessParenthesesCheck - squid:S1905, Multiple quality improve…

### DIFF
--- a/bible/src/main/java/com/BibleQuote/controllers/FsBookController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/FsBookController.java
@@ -70,7 +70,7 @@ public class FsBookController implements IBookController {
 		long startTime = System.currentTimeMillis();
 		LinkedHashMap<String, String> result = new SearchProcessor(bRepository)
 				.search(module, getBookList(module, fromBookID, toBookID), query);
-		Log.i(TAG, String.format("Search time: %d ms", (System.currentTimeMillis() - startTime)));
+		Log.i(TAG, String.format("Search time: %d ms", System.currentTimeMillis() - startTime));
 
 		return result;
 	}

--- a/bible/src/main/java/com/BibleQuote/dal/FsLibraryContext.java
+++ b/bible/src/main/java/com/BibleQuote/dal/FsLibraryContext.java
@@ -285,7 +285,7 @@ public class FsLibraryContext extends LibraryContext {
                 throw new BookDefinitionException(message, module.getDataSourceID(), i, pathNames.get(i), fullNames.get(i), shortNames.get(i), chapterQty.get(i));
             }
             FsBook book = new FsBook(module, fullNames.get(i), pathNames.get(i),
-                    (shortNames.size() > i ? shortNames.get(i) : ""),
+                    shortNames.size() > i ? shortNames.get(i) : "",
                     chapterQty.get(i));
             module.Books.put(book.getID(), book);
         }

--- a/bible/src/main/java/com/BibleQuote/dal/dbLibraryHelper.java
+++ b/bible/src/main/java/com/BibleQuote/dal/dbLibraryHelper.java
@@ -63,9 +63,9 @@ public final class dbLibraryHelper {
 				+ ");"
 	};
 
-	private static final String DB_DIR_PATH = (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
+	private static final String DB_DIR_PATH = Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
 			? DataConstants.DB_EXTERNAL_DATA_PATH
-			: DataConstants.DB_DATA_PATH);
+			: DataConstants.DB_DATA_PATH;
 
 	private static SQLiteDatabase getDB() {
 		File dbDir = new File(DB_DIR_PATH);

--- a/bible/src/main/java/com/BibleQuote/entity/BibleReference.java
+++ b/bible/src/main/java/com/BibleQuote/entity/BibleReference.java
@@ -63,8 +63,8 @@ public class BibleReference {
                 this.chapterNumber = 1;
                 this.fromVerse = 1;
                 try {
-                    this.chapterNumber = (linkParam.length >= 3 ? Integer.parseInt(linkParam[2]) : 1);
-                    this.fromVerse = (linkParam.length >= 4 ? Integer.parseInt(linkParam[3]) : 1);
+                    this.chapterNumber = linkParam.length >= 3 ? Integer.parseInt(linkParam[2]) : 1;
+                    this.fromVerse = linkParam.length >= 4 ? Integer.parseInt(linkParam[3]) : 1;
                     this.toVerse = fromVerse;
                 } catch (NumberFormatException e) {
                     e.printStackTrace();

--- a/bible/src/main/java/com/BibleQuote/ui/ReaderActivity.java
+++ b/bible/src/main/java/com/BibleQuote/ui/ReaderActivity.java
@@ -252,7 +252,7 @@ public class ReaderActivity extends BibleQuoteActivity implements OnTaskComplete
     public void onTaskComplete(Task task) {
         if (task != null && !task.isCancelled()) {
             if (task instanceof AsyncOpenChapter) {
-                AsyncOpenChapter t = ((AsyncOpenChapter) task);
+                AsyncOpenChapter t = (AsyncOpenChapter) task;
                 if (t.isSuccess()) {
                     chapterInHTML = myLibrarian.getChapterHTMLView();
                     setTextInWebView();

--- a/bible/src/main/java/com/BibleQuote/ui/fragments/TTSPlayerFragment.java
+++ b/bible/src/main/java/com/BibleQuote/ui/fragments/TTSPlayerFragment.java
@@ -106,7 +106,7 @@ public class TTSPlayerFragment extends Fragment implements PlayerView.OnClickLis
         } else if (ev == TTSPlayerController.Event.ChangeTextIndex) {
             int nextTextIndex = ttsController.getCurrText();
             TreeSet<Integer> selected = new TreeSet<Integer>();
-            selected.add((++nextTextIndex));
+            selected.add(++nextTextIndex);
             webView.setSelectedVerse(selected);
             webView.gotoVerse(nextTextIndex);
         } else if (ev == TTSPlayerController.Event.PauseSpeak) {

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/AlphaPatternDrawable.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/AlphaPatternDrawable.java
@@ -76,7 +76,7 @@ public class AlphaPatternDrawable extends Drawable {
 		int height = bounds.height();
 		int width = bounds.width();
 
-		numRectanglesHorizontal = (int) Math.ceil((width / mRectangleSize));
+		numRectanglesHorizontal = (int) Math.ceil(width / mRectangleSize);
 		numRectanglesVertical = (int) Math.ceil(height / mRectangleSize);
 
 		generatePatternBitmap();

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/ColorPickerView.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/ColorPickerView.java
@@ -716,7 +716,7 @@ public class ColorPickerView extends View{
 
 			if(widthMode == MeasureSpec.EXACTLY && heightMode != MeasureSpec.EXACTLY) {
 				//The with has been specified exactly, we need to adopt the height to fit.
-				int h = (int) (widthAllowed - mPanelSpacingPx - mHuePanelWidthPx);
+				int h = widthAllowed - mPanelSpacingPx - mHuePanelWidthPx;
 
 				if(mShowAlphaPanel) {
 					h += mPanelSpacingPx + mAlphaPanelHeightPx;
@@ -736,7 +736,7 @@ public class ColorPickerView extends View{
 			else if(heightMode == MeasureSpec.EXACTLY && widthMode != MeasureSpec.EXACTLY) {
 				//The height has been specified exactly, we need to stay within this height and adopt the width.
 
-				int w = (int) (heightAllowed + mPanelSpacingPx + mHuePanelWidthPx);
+				int w = heightAllowed + mPanelSpacingPx + mHuePanelWidthPx;
 
 				if(mShowAlphaPanel) {
 					w -= (mPanelSpacingPx + mAlphaPanelHeightPx);
@@ -769,10 +769,10 @@ public class ColorPickerView extends View{
 			//within the allowed space.
 
 			//Calculate the needed width to layout using max allowed height.
-			int widthNeeded = (int) (heightAllowed + mPanelSpacingPx + mHuePanelWidthPx);
+			int widthNeeded = heightAllowed + mPanelSpacingPx + mHuePanelWidthPx;
 
 			//Calculate the needed height to layout using max allowed width.
-			int heightNeeded = (int) (widthAllowed - mPanelSpacingPx - mHuePanelWidthPx);
+			int heightNeeded = widthAllowed - mPanelSpacingPx - mHuePanelWidthPx;
 
 			if(mShowAlphaPanel) {
 				widthNeeded -= (mPanelSpacingPx + mAlphaPanelHeightPx);

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ReaderWebView.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ReaderWebView.java
@@ -141,7 +141,7 @@ public class ReaderWebView extends WebView
 		int scrollY = getScrollY();
 		int scrollExtent = computeVerticalScrollExtent();
 		int scrollPos = scrollY + scrollExtent;
-		return (scrollPos >= (computeVerticalScrollRange() - 10));
+		return scrollPos >= (computeVerticalScrollRange() - 10);
 	}
 
 	public void computeScroll() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S1905 - Redundant casts should not be used


You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905

Please let me know if you have any questions.

M-Ezzat