### PR TITLE
Cleanup - squid:S2974 - Classes without public constructors should be…

### DIFF
--- a/bible/src/main/java/com/BibleQuote/controllers/LibraryController.java
+++ b/bible/src/main/java/com/BibleQuote/controllers/LibraryController.java
@@ -33,7 +33,7 @@ import com.BibleQuote.utils.DataConstants;
 
 import java.io.File;
 
-public class LibraryController {
+public final class LibraryController {
 
 	private static volatile LibraryController instance;
 

--- a/bible/src/main/java/com/BibleQuote/entity/search/SearchProcessor.java
+++ b/bible/src/main/java/com/BibleQuote/entity/search/SearchProcessor.java
@@ -77,7 +77,7 @@ public class SearchProcessor {
 		return searchRes;
 	}
 
-	private class SearchThread implements Runnable {
+	private final class SearchThread implements Runnable {
         private CountDownLatch latch;
         private Module module;
         private String bookID;

--- a/bible/src/main/java/com/BibleQuote/managers/GoogleAnalyticsHelper.java
+++ b/bible/src/main/java/com/BibleQuote/managers/GoogleAnalyticsHelper.java
@@ -27,7 +27,7 @@ import com.google.android.gms.analytics.HitBuilders;
  * @author Vladimir Yakushev
  * @version 1.0
  */
-public class GoogleAnalyticsHelper {
+public final class GoogleAnalyticsHelper {
     private final static String CAATEGORY_BOOKMARKS = "bookmarks";
     private static final String CATEGORY_MODULES = "modules";
     private static final String CATEGORY_SEARCH = "search";

--- a/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/DrawingUtils.java
+++ b/bible/src/main/java/com/BibleQuote/ui/widget/ColorPicker/DrawingUtils.java
@@ -8,7 +8,7 @@ import android.util.TypedValue;
  * @author Vladimir Yakushev
  * @version 1.0 of 03.2016
  */
-public class DrawingUtils {
+public final class DrawingUtils {
 
     private DrawingUtils() throws InstantiationException {
         throw new InstantiationException("This class is not for instantiation");

--- a/bible/src/main/java/com/BibleQuote/utils/DataConstants.java
+++ b/bible/src/main/java/com/BibleQuote/utils/DataConstants.java
@@ -4,7 +4,7 @@ import android.os.Environment;
 
 import java.io.File;
 
-public class DataConstants {
+public final class DataConstants {
 
 	private static final String APP_PACKAGE_NAME = "com.BibleQuote";
 	private static final String APP_DIR_NAME = "BibleQuote";

--- a/bible/src/main/java/com/BibleQuote/utils/DevicesKeyCodes.java
+++ b/bible/src/main/java/com/BibleQuote/utils/DevicesKeyCodes.java
@@ -2,7 +2,7 @@ package com.BibleQuote.utils;
 
 import android.view.KeyEvent;
 
-public class DevicesKeyCodes {
+public final class DevicesKeyCodes {
 
 	// additional key codes for Nook
 	public static final int NOOK_KEY_PREV_LEFT = 96;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat